### PR TITLE
Separate Report Endpoints

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,8 +8,8 @@ import (
 	"uptime-go/internal/api"
 	"uptime-go/internal/configuration"
 	"uptime-go/internal/helper"
-	"uptime-go/internal/monitor"
 	"uptime-go/internal/models"
+	"uptime-go/internal/monitor"
 	"uptime-go/internal/net"
 	"uptime-go/internal/net/database"
 
@@ -75,6 +75,7 @@ Example:
 			"tls_handshake_timeout",
 			"response_header_timeout",
 		})
+
 		db.DB.Where("url IN ?", urls).Find(&configs)
 		for _, cfg := range configs {
 			src, ok := configByURL[cfg.URL]

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -3,14 +3,41 @@ package api
 import (
 	"io"
 	"net/http"
+	"time"
 	"uptime-go/internal/configuration"
+	"uptime-go/internal/models"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
 )
 
 type ReportQueryParams struct {
+	WithStat bool `form:"with_stat"`
+}
+
+type HistoryReportQueryParams struct {
 	URL   string `form:"url"`
 	Limit int    `form:"limit"`
+	From  string `form:"from"`
+	To    string `form:"to"`
+}
+
+type MonitorDailyUptimeStats struct {
+	Date             string  `json:"date"`
+	UptimePercentage float64 `json:"uptime_percentage"`
+	TotalChecks      int     `json:"total_checks"`
+}
+
+type MonitorWithDailyUptimeStats struct {
+	models.Monitor
+	DailyStats []MonitorDailyUptimeStats `json:"stats,omitempty"`
+}
+
+func (s *Server) HealthCheckHandler(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"status":  "healthy",
+		"service": "uptime-go",
+	})
 }
 
 func (s *Server) UpdateConfigHandler(c *gin.Context) {
@@ -21,7 +48,8 @@ func (s *Server) UpdateConfigHandler(c *gin.Context) {
 	}
 
 	if err := configuration.UpdateConfig(s.configPath, body); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"message": "Failed to update configuration", "error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Failed to update configuration"})
+		log.Err(err).Msg("Error updating configuration")
 		return
 	}
 
@@ -29,44 +57,168 @@ func (s *Server) UpdateConfigHandler(c *gin.Context) {
 }
 
 func (s *Server) GetMonitoringReport(c *gin.Context) {
-	var queryParams ReportQueryParams
+	var params ReportQueryParams
 
-	if err := c.ShouldBindQuery(&queryParams); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid query parameters", "error": err.Error()})
+	if err := c.ShouldBindQuery(&params); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "Invalid query parameters",
+		})
 		return
 	}
 
-	if queryParams.Limit == 0 {
-		queryParams.Limit = 1000
+	var urls []string
+	for _, m := range configuration.Config.Monitor {
+		urls = append(urls, m.URL)
 	}
 
-	if queryParams.URL == "" {
-		monitors, err := s.db.GetAllMonitors()
+	monitors, err := s.db.GetMonitors(urls)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"message": "Failed to retrieve monitors",
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	if params.WithStat {
+		var monitorStats []MonitorWithDailyUptimeStats
+
+		now := time.Now().UTC()
+		today := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999999999, now.Location())
+		ninetyDaysAgo := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, today.Location()).AddDate(0, 0, -89)
+
+		monitorURLs := make([]string, 0, len(monitors))
+		for _, m := range monitors {
+			monitorURLs = append(monitorURLs, m.URL)
+		}
+
+		histories, err := s.db.GetHistoryWithMonitor(monitorURLs, ninetyDaysAgo, today)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"message": "Failed to retrieve monitors", "error": err.Error()})
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": "Failed to retrieve monitor histories for stats calculation",
+			})
 			return
 		}
-		c.JSON(http.StatusOK, monitors)
+
+		for _, monitor := range monitors {
+			histories, _ := histories[monitor.URL]
+			dailyStats := calculateUptimeStats(histories, ninetyDaysAgo, today)
+
+			monitorStats = append(monitorStats, MonitorWithDailyUptimeStats{
+				Monitor:    monitor,
+				DailyStats: dailyStats,
+			})
+		}
+		c.JSON(http.StatusOK, monitorStats)
 		return
 	}
 
-	monitor, err := s.db.GetMonitorWithHistories(queryParams.URL, queryParams.Limit)
+	c.JSON(http.StatusOK, monitors)
+}
+
+func (s *Server) GetMonitoringHistoryReport(c *gin.Context) {
+	var params HistoryReportQueryParams
+
+	if err := c.ShouldBindQuery(&params); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "Invalid query parameters",
+		})
+		return
+	}
+
+	if params.URL == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "URL parameter is required",
+		})
+		return
+	}
+
+	if params.Limit == 0 {
+		params.Limit = 1000
+	}
+
+	var from, to time.Time
+
+	if params.From != "" && params.To != "" {
+		var err error
+
+		from, err = time.Parse("2006-01-02", params.From)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid 'from' date format. Please use YYYY-MM-DD."})
+			return
+		}
+
+		to, err = time.Parse("2006-01-02", params.To)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid 'to' date format. Please use YYYY-MM-DD."})
+			return
+		}
+
+		to = to.Add(23*time.Hour + 59*time.Minute + 59*time.Second)
+	}
+
+	monitor, err := s.db.GetMonitorHistories(params.URL, params.Limit, from, to)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"message": "Failed to retrieve monitor details", "error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"message": "Failed to retrieve monitor history",
+		})
 		return
 	}
 
 	if monitor == nil {
-		c.JSON(http.StatusNotFound, gin.H{"message": "Record not found"})
+		c.JSON(http.StatusNotFound, gin.H{
+			"message": "Record not found for the given URL",
+		})
 		return
 	}
 
 	c.JSON(http.StatusOK, monitor)
 }
 
-func (s *Server) HealthCheckHandler(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{
-		"status":  "healthy",
-		"service": "uptime-go",
+func calculateUptimeStats(histories []models.MonitorHistory, from, to time.Time) []MonitorDailyUptimeStats {
+	dailyStatsMap := make(map[string]struct {
+		UpCount    int
+		TotalCount int
 	})
+
+	for d := from; !d.After(to); d = d.Add(24 * time.Hour) {
+		dateStr := d.Format("2006-01-02")
+		dailyStatsMap[dateStr] = struct {
+			UpCount    int
+			TotalCount int
+		}{UpCount: 0, TotalCount: 0}
+	}
+
+	for _, history := range histories {
+		dateStr := history.CreatedAt.Format("2006-01-02")
+		stats := dailyStatsMap[dateStr]
+		stats.TotalCount++
+		if history.IsUp {
+			stats.UpCount++
+		}
+		dailyStatsMap[dateStr] = stats
+	}
+
+	var result []MonitorDailyUptimeStats
+	for d := from; !d.After(to); d = d.Add(24 * time.Hour) {
+		dateStr := d.Format("2006-01-02")
+		stats := dailyStatsMap[dateStr]
+		uptimePercentage := 0.0
+		if stats.TotalCount > 0 {
+			uptimePercentage = (float64(stats.UpCount) / float64(stats.TotalCount)) * 100
+		}
+
+		result = append(result, MonitorDailyUptimeStats{
+			Date:             dateStr,
+			UptimePercentage: uptimePercentage,
+			TotalChecks:      stats.TotalCount,
+		})
+	}
+
+	// If no histories at all, return nil to omit "stats" field in JSON response
+	if len(histories) == 0 {
+		return nil
+	}
+
+	return result
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -74,11 +74,11 @@ func (s *Server) setupRoutes() {
 	s.router.GET("/health", s.HealthCheckHandler)
 
 	api := s.router.Group("/api/uptime-go")
-	// api.GET("/config")
 	api.POST("/config", s.UpdateConfigHandler)
 
 	reportGroup := api.Group("/reports")
-	reportGroup.GET("", s.GetMonitoringReport)
+	reportGroup.GET("/", s.GetMonitoringReport)
+	reportGroup.GET("/history", s.GetMonitoringHistoryReport)
 }
 
 func accessLogger() gin.HandlerFunc {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,20 +1,17 @@
 package models
 
 import (
-	"encoding/json"
-	"fmt"
 	"time"
 	"uptime-go/internal/helper"
 	"uptime-go/internal/incident"
 
-	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 )
 
 type Monitor struct {
 	ID                       string           `json:"-" gorm:"primaryKey"`
 	URL                      string           `json:"url" gorm:"unique"`
-	Enabled                  bool             `json:"-"`
+	Enabled                  bool             `json:"enabled"`
 	Interval                 time.Duration    `json:"-"`
 	ResponseTimeThreshold    time.Duration    `json:"-"`
 	CertificateMonitoring    bool             `json:"-"`
@@ -23,7 +20,7 @@ type Monitor struct {
 	IPType                   string           `json:"-"`
 	IsUp                     *bool            `json:"is_up"`
 	StatusCode               *int             `json:"status_code"`
-	ResponseTime             *int64           `json:"response_time"`
+	ResponseTime             *int64           `json:"response_time"` // in milliseconds
 	CertificateExpiredDate   *time.Time       `json:"certificate_expired_date"`
 	LastUp                   *time.Time       `json:"last_up"`
 	LastDown                 *time.Time       `json:"last_down"`
@@ -65,11 +62,6 @@ type Incident struct {
 	Monitor     Monitor       `gorm:"foreignKey:MonitorID"`
 }
 
-type Response struct {
-	Message string `json:"message"`
-	Data    any    `json:"data,omitempty"`
-}
-
 func (h *MonitorHistory) BeforeCreate(tx *gorm.DB) (err error) {
 	h.ID = helper.GenerateRandomID()
 
@@ -94,15 +86,4 @@ func (i Incident) IsNotExists() bool {
 
 func (i Incident) IsSolved() bool {
 	return i.SolvedAt != nil
-}
-
-func (r Response) Print() {
-	data, err := json.Marshal(r)
-
-	if err != nil {
-		log.Error().Err(err).Msg("error serializing response")
-		return
-	}
-
-	fmt.Println(string(data))
 }

--- a/internal/net/database/database.go
+++ b/internal/net/database/database.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -123,32 +124,73 @@ func (db *Database) Upsert(record any) error {
 	return db.UpsertRecord(record, "id", nil)
 }
 
-func (db *Database) GetAllMonitors() ([]models.Monitor, error) {
+func (db *Database) GetMonitors(urls []string) ([]models.Monitor, error) {
 	var monitors []models.Monitor
 	db.mutex.RLock()
 	defer db.mutex.RUnlock()
 
-	if err := db.DB.Find(&monitors).Error; err != nil {
-		return nil, fmt.Errorf("failed to get all monitors: %w", err)
+	if err := db.DB.
+		Where("url IN ?", urls).
+		Find(&monitors).Error; err != nil {
+		return nil, fmt.Errorf("failed to get monitors by config URLs: %w", err)
 	}
+
 	return monitors, nil
 }
 
-func (db *Database) GetMonitorWithHistories(url string, limit int) (*models.Monitor, error) {
+func (db *Database) GetMonitorHistories(url string, limit int, from time.Time, to time.Time) (*models.Monitor, error) {
 	var monitor models.Monitor
 	db.mutex.RLock()
 	defer db.mutex.RUnlock()
 
-	if err := db.DB.
+	err := db.DB.
 		Preload("Histories", func(db *gorm.DB) *gorm.DB {
-			return db.Order("monitor_histories.created_at DESC").Limit(limit)
+			query := db.Order("monitor_histories.created_at DESC")
+
+			if !from.IsZero() && !to.IsZero() {
+				query = query.Where("created_at BETWEEN ? AND ?", from, to)
+			}
+
+			if limit > 0 {
+				query = query.Limit(limit)
+			}
+
+			return query
 		}).
 		Where("url = ?", url).
-		Find(&monitor).Error; err != nil {
+		First(&monitor).Error
+
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+
 		return nil, fmt.Errorf("failed to get monitor with histories for URL %s: %w", url, err)
 	}
 
 	return &monitor, nil
+}
+
+func (db *Database) GetHistoryWithMonitor(urls []string, from, to time.Time) (map[string][]models.MonitorHistory, error) {
+	allHistories := make([]models.MonitorHistory, 0)
+	db.mutex.RLock()
+	defer db.mutex.RUnlock()
+
+	if err := db.DB.
+		Preload("Monitor").
+		Joins("JOIN monitors ON monitors.id = monitor_histories.monitor_id").
+		Where("monitors.url IN ? AND monitor_histories.created_at BETWEEN ? AND ?", urls, from, to).
+		Order("monitors.url ASC, monitor_histories.created_at ASC").
+		Find(&allHistories).Error; err != nil {
+		return nil, fmt.Errorf("failed to get monitor histories for URLs %v in date range %s to %s: %w", urls, from, to, err)
+	}
+
+	histories := make(map[string][]models.MonitorHistory)
+	for _, history := range allHistories {
+		histories[history.Monitor.URL] = append(histories[history.Monitor.URL], history)
+	}
+
+	return histories, nil
 }
 
 func (db *Database) GetLastIncident(url string, incidentType incident.Type) *models.Incident {

--- a/internal/net/net_test.go
+++ b/internal/net/net_test.go
@@ -151,9 +151,9 @@ func TestCheckWebsiteIPv4Only(t *testing.T) {
 
 	url := "http://" + listener.Addr().String()
 	nc := NetworkConfig{
-		URL:       url,
-		Timeout:   5 * time.Second,
-		IPType:    "ipv4",
+		URL:     url,
+		Timeout: 5 * time.Second,
+		IPType:  "ipv4",
 	}
 
 	results, err := nc.CheckWebsite()
@@ -186,9 +186,9 @@ func TestCheckWebsiteIPv6Only(t *testing.T) {
 	addr := listener.Addr().(*net.TCPAddr)
 	url := fmt.Sprintf("http://[%s]:%d", addr.IP.String(), addr.Port)
 	nc := NetworkConfig{
-		URL:       url,
-		Timeout:   5 * time.Second,
-		IPType:    "ipv6",
+		URL:     url,
+		Timeout: 5 * time.Second,
+		IPType:  "ipv6",
 	}
 
 	results, err := nc.CheckWebsite()


### PR DESCRIPTION
## What's New

### 1. Monitor History Endpoint Refactor

* Separated monitor history from `/reports`

* Previous:

  ```
  GET /reports?url=
  ```

* Now:

  ```
  GET /reports/history?url=
  ```

* Added `from` and `to` query parameters to `/reports/history`
  This allows filtering monitor history within a specific date range.

Example:

```
GET /reports/history?url=https://example.com&from=2026-02-01&to=2026-02-25
```

---

### 2. Enhanced `/reports` Endpoint

* `/reports` now includes aggregated `stats` data
  (intended for status page usage)

Example response:

```json
{
  "url": "https://github.com",
  "enabled": true,
  "is_up": true,
  "status_code": 200,
  "response_time": 1834,
  "certificate_expired_date": "2026-05-17T09:25:10Z",
  "last_up": "2026-02-24T03:42:23.630409388Z",
  "last_down": "2026-02-24T03:32:23.29108392Z",
  "last_check": "2026-02-25T01:50:42.088319139Z",
  "stats": [
    {
      "date": "2025-11-28",
      "uptime_percentage": 0,
      "total_checks": 50
    }
  ]
}
```

---

## ⚠️ Breaking Changes

* Monitor history is no longer returned from `/reports`
* Clients must use `/reports/history` for historical data