### PR TITLE
Improve timeout error messages

### DIFF
--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -248,7 +248,15 @@ func (m *UptimeMonitor) handleWebsiteDown(monitor *models.Monitor, result *net.C
 			incidentType = incident.Timeout
 			result.ResponseTime = monitor.ResponseTimeThreshold
 			if description == "" {
-				description = fmt.Sprintf("Request timed out after %v: %s", monitor.ResponseTimeThreshold, monitor.URL)
+				nc := &net.NetworkConfig{
+					URL:                   monitor.URL,
+					Timeout:               monitor.ResponseTimeThreshold,
+					DNSTimeout:            monitor.DNSTimeout,
+					DialTimeout:           monitor.DialTimeout,
+					TLSHandshakeTimeout:   monitor.TLSHandshakeTimeout,
+					ResponseHeaderTimeout: monitor.ResponseHeaderTimeout,
+				}
+				description = nc.CategorizeError(err)
 			}
 		} else {
 			if description == "" {

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -1,10 +1,12 @@
 package monitor
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 	"uptime-go/internal/incident"
@@ -77,6 +79,46 @@ func TestMonitorHandleWebsiteDown(t *testing.T) {
 			assert.Equal(t, tc.expectedIncidentType, incidentType)
 		})
 	}
+}
+
+func TestMonitorHandleWebsiteDownUsesClearTimeoutDescription(t *testing.T) {
+	db, _ := database.InitializeTestDatabase()
+	uptimeMonitor, _ := NewUptimeMonitor(db, nil)
+	monitor := models.Monitor{
+		ID:                    "monitor-1",
+		URL:                   "https://example.com",
+		ResponseTimeThreshold: 30 * time.Second,
+	}
+	checkResult := net.CheckResults{}
+
+	created, incidentType := uptimeMonitor.handleWebsiteDown(&monitor, &checkResult, context.DeadlineExceeded)
+	assert.True(t, created)
+	assert.Equal(t, incident.Timeout, incidentType)
+
+	lastIncident := db.GetLastIncident(monitor.URL, incident.Timeout)
+	assert.True(t, lastIncident.IsExists())
+	assert.Contains(t, lastIncident.Description, "Overall request timeout after 30s for https://example.com")
+	assert.Contains(t, lastIncident.Description, "response_time_threshold")
+	assert.False(t, strings.Contains(lastIncident.Description, "Request timed out:"))
+}
+
+func TestMonitorHandleWebsiteDownKeepsExistingErrorMessage(t *testing.T) {
+	db, _ := database.InitializeTestDatabase()
+	uptimeMonitor, _ := NewUptimeMonitor(db, nil)
+	monitor := models.Monitor{
+		ID:                    "monitor-1",
+		URL:                   "https://example.com",
+		ResponseTimeThreshold: 30 * time.Second,
+	}
+	checkResult := net.CheckResults{ErrorMessage: "custom timeout details"}
+
+	created, incidentType := uptimeMonitor.handleWebsiteDown(&monitor, &checkResult, context.DeadlineExceeded)
+	assert.True(t, created)
+	assert.Equal(t, incident.Timeout, incidentType)
+
+	lastIncident := db.GetLastIncident(monitor.URL, incident.Timeout)
+	assert.True(t, lastIncident.IsExists())
+	assert.Equal(t, "custom timeout details", lastIncident.Description)
 }
 
 func TestDetermineStatus(t *testing.T) {

--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -203,7 +203,7 @@ func (nc *NetworkConfig) CheckWebsite() (*CheckResults, error) {
 	result.FirstByteTime = responseTime - result.DNSTime - result.ConnectTime
 
 	if err != nil {
-		result.ErrorMessage = nc.categorizeError(err, dnsTimeout, dialTimeout)
+		result.ErrorMessage = nc.categorizeError(err, totalTimeout, dnsTimeout, dialTimeout, tlsTimeout, headerTimeout)
 		return result, err
 	}
 	defer resp.Body.Close()
@@ -225,60 +225,90 @@ func (nc *NetworkConfig) CheckWebsite() (*CheckResults, error) {
 	return result, nil
 }
 
-// categorizeError provides more detailed error messages based on the type of failure
-func (nc *NetworkConfig) categorizeError(err error, dnsTimeout, dialTimeout time.Duration) string {
-	// Check for context timeout
-	if errors.Is(err, context.DeadlineExceeded) {
-		return fmt.Sprintf("Request timed out after %v (overall deadline): %s", nc.Timeout, nc.URL)
+func (nc *NetworkConfig) CategorizeError(err error) string {
+	totalTimeout, dnsTimeout, dialTimeout, tlsTimeout, headerTimeout := nc.timeoutDefaults()
+	return nc.categorizeError(err, totalTimeout, dnsTimeout, dialTimeout, tlsTimeout, headerTimeout)
+}
+
+func (nc *NetworkConfig) timeoutDefaults() (time.Duration, time.Duration, time.Duration, time.Duration, time.Duration) {
+	dnsTimeout := nc.DNSTimeout
+	if dnsTimeout == 0 {
+		dnsTimeout = 5 * time.Second
 	}
 
-	// Network operation errors
+	dialTimeout := nc.DialTimeout
+	if dialTimeout == 0 {
+		dialTimeout = 10 * time.Second
+	}
+
+	tlsTimeout := nc.TLSHandshakeTimeout
+	if tlsTimeout == 0 {
+		tlsTimeout = 10 * time.Second
+	}
+
+	headerTimeout := nc.ResponseHeaderTimeout
+	if headerTimeout == 0 {
+		headerTimeout = 20 * time.Second
+	}
+
+	totalTimeout := nc.Timeout
+	if totalTimeout == 0 {
+		totalTimeout = 30 * time.Second
+	}
+
+	return totalTimeout, dnsTimeout, dialTimeout, tlsTimeout, headerTimeout
+}
+
+// categorizeError provides more detailed error messages based on the type of failure
+func (nc *NetworkConfig) categorizeError(err error, totalTimeout, dnsTimeout, dialTimeout, tlsTimeout, headerTimeout time.Duration) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Sprintf("Overall request timeout after %v for %s. The site did not complete the check within response_time_threshold.", totalTimeout, nc.URL)
+	}
+
 	var opErr *net.OpError
 	if errors.As(err, &opErr) {
-		if opErr.Timeout() {
-			switch opErr.Op {
-			case "dial":
-				return fmt.Sprintf("TCP connection timeout (%v): %s", dialTimeout, nc.URL)
-			case "read":
-				return fmt.Sprintf("Read timeout while waiting for response: %s", nc.URL)
-			default:
-				return fmt.Sprintf("Network timeout during %s: %s", opErr.Op, nc.URL)
-			}
-		}
-
-		// DNS errors
 		var dnsErr *net.DNSError
 		if errors.As(opErr.Err, &dnsErr) {
 			if dnsErr.Timeout() {
-				return fmt.Sprintf("DNS resolution timeout (%v): %s", dnsTimeout, nc.URL)
+				return fmt.Sprintf("DNS resolution timeout after %v for %s. Check DNS records/resolver or increase dns_timeout.", dnsTimeout, nc.URL)
 			}
 			return fmt.Sprintf("DNS resolution failed for %s: %v", nc.URL, dnsErr)
+		}
+
+		if opErr.Timeout() {
+			switch opErr.Op {
+			case "dial":
+				return fmt.Sprintf("TCP connection timeout after %v for %s. Check firewall, routing, server reachability, or increase dial_timeout.", dialTimeout, nc.URL)
+			case "read":
+				return fmt.Sprintf("Response timeout after %v for %s. The server accepted the connection but did not send a response in time; check application latency or increase response_header_timeout.", headerTimeout, nc.URL)
+			default:
+				return fmt.Sprintf("Network timeout during %s for %s. The request exceeded a configured network timeout.", opErr.Op, nc.URL)
+			}
 		}
 
 		return fmt.Sprintf("Network operation error for %s: %s - %v", nc.URL, opErr.Op, opErr.Err)
 	}
 
-	// EOF errors
 	if errors.Is(err, io.EOF) {
 		return fmt.Sprintf("Connection closed prematurely (EOF) while fetching %s", nc.URL)
 	}
 
-	// TLS errors
 	var tlsErr tls.RecordHeaderError
 	if errors.As(err, &tlsErr) {
 		return fmt.Sprintf("TLS handshake failed for %s: invalid record header", nc.URL)
 	}
 
-	// URL errors
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {
 		if urlErr.Timeout() {
-			return fmt.Sprintf("URL request timeout: %s", nc.URL)
+			if strings.Contains(strings.ToLower(urlErr.Err.Error()), "tls handshake timeout") {
+				return fmt.Sprintf("TLS handshake timeout after %v for %s. Check TLS/certificate configuration or increase tls_handshake_timeout.", tlsTimeout, nc.URL)
+			}
+			return fmt.Sprintf("HTTP request timeout for %s. The request exceeded a configured timeout before a complete response was received.", nc.URL)
 		}
 		return fmt.Sprintf("URL error for %s: %v", nc.URL, urlErr.Err)
 	}
 
-	// Generic error
 	return fmt.Sprintf("Failed to fetch %s: %v", nc.URL, err)
 }
 

--- a/internal/net/net_test.go
+++ b/internal/net/net_test.go
@@ -1,10 +1,12 @@
 package net
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -100,6 +102,81 @@ func TestCheckWebsiteErrorMessages(t *testing.T) {
 	}
 }
 
+func TestCategorizeErrorUsesClearTimeoutMessages(t *testing.T) {
+	nc := NetworkConfig{
+		URL:                   "https://example.com",
+		Timeout:               30 * time.Second,
+		DNSTimeout:            5 * time.Second,
+		DialTimeout:           10 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 20 * time.Second,
+	}
+
+	tests := []struct {
+		name         string
+		err          error
+		wantContains []string
+	}{
+		{
+			name: "overall timeout",
+			err:  context.DeadlineExceeded,
+			wantContains: []string{
+				"Overall request timeout after 30s for https://example.com",
+				"response_time_threshold",
+			},
+		},
+		{
+			name: "url timeout fallback",
+			err:  &url.Error{Op: "Get", URL: "https://example.com", Err: context.DeadlineExceeded},
+			wantContains: []string{
+				"Overall request timeout after 30s for https://example.com",
+				"response_time_threshold",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := nc.CategorizeError(tt.err)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(msg, want) {
+					t.Fatalf("expected %q to contain %q", msg, want)
+				}
+			}
+			if strings.Contains(msg, "URL request timeout") || strings.Contains(msg, "Request timed out:") {
+				t.Fatalf("expected clear timeout message, got %q", msg)
+			}
+		})
+	}
+}
+
+func TestCheckWebsiteTimeoutMessageIsActionable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	nc := NetworkConfig{
+		URL:     server.URL,
+		Timeout: 10 * time.Millisecond,
+	}
+
+	results, err := nc.CheckWebsite()
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if results == nil {
+		t.Fatal("expected results")
+	}
+	if !strings.Contains(results.ErrorMessage, "Overall request timeout after 10ms") {
+		t.Fatalf("expected overall timeout message, got %q", results.ErrorMessage)
+	}
+	if !strings.Contains(results.ErrorMessage, "response_time_threshold") {
+		t.Fatalf("expected actionable config hint, got %q", results.ErrorMessage)
+	}
+}
+
 func TestCheckWebsiteSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -151,9 +228,9 @@ func TestCheckWebsiteIPv4Only(t *testing.T) {
 
 	url := "http://" + listener.Addr().String()
 	nc := NetworkConfig{
-		URL:       url,
-		Timeout:   5 * time.Second,
-		IPType:    "ipv4",
+		URL:     url,
+		Timeout: 5 * time.Second,
+		IPType:  "ipv4",
 	}
 
 	results, err := nc.CheckWebsite()
@@ -186,9 +263,9 @@ func TestCheckWebsiteIPv6Only(t *testing.T) {
 	addr := listener.Addr().(*net.TCPAddr)
 	url := fmt.Sprintf("http://[%s]:%d", addr.IP.String(), addr.Port)
 	nc := NetworkConfig{
-		URL:       url,
-		Timeout:   5 * time.Second,
-		IPType:    "ipv6",
+		URL:     url,
+		Timeout: 5 * time.Second,
+		IPType:  "ipv6",
 	}
 
 	results, err := nc.CheckWebsite()


### PR DESCRIPTION
## Summary
- Replace generic timeout fallback text with actionable timeout descriptions.
- Reuse the network error classifier for monitor incident timeout descriptions.
- Add tests covering clear timeout messages and incident fallback behavior.

## Test plan
- [x] go test ./internal/net ./internal/monitor
- [x] go test ./...